### PR TITLE
Release v0.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fynyky/elemental",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Simple reactive ui building without frameworks",
   "type": "module",
   "main": "dist/main.js",


### PR DESCRIPTION
Prepare release v0.0.3

- Update version in package.json from 0.0.2 to 0.0.3
- All tests passing across Chromium, Firefox, and Webkit
- Ready to cut release