### PR TITLE
Switch npm publish to Trusted Publishing via OIDC

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -16,5 +18,3 @@ jobs:
       - run: npx playwright install --with-deps
       - run: npm test
       - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Removes the NPM_TOKEN secret dependency and adds the id-token: write permission so GitHub Actions can authenticate directly with npm.