### PR TITLE
Upgrade setup-node to v4 for OIDC Trusted Publishing support

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,7 +10,7 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org/


### PR DESCRIPTION
setup-node@v3 does not support npm Trusted Publishing — v4 is required to exchange the GitHub OIDC token for a short-lived npm publish token.