### PR TITLE
Add --provenance flag to npm publish for Trusted Publishing auth

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,4 +17,4 @@ jobs:
       - run: npm ci
       - run: npx playwright install --with-deps
       - run: npm test
-      - run: npm publish --access public
+      - run: npm publish --access public --provenance


### PR DESCRIPTION
npm Trusted Publishing authenticates via the provenance mechanism. Without --provenance, the OIDC token is not used and publish fails with 404.