### PR TITLE
Remove registry-url from setup-node to fix Trusted Publishing auth

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -13,7 +13,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npx playwright install --with-deps
       - run: npm test


### PR DESCRIPTION
setup-node's registry-url injects a NODE_AUTH_TOKEN-based .npmrc that conflicts with the OIDC auth used by --provenance. Removing it lets npm handle the OIDC token exchange directly.