### PR TITLE
Add on() shorthand for addEventListener

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ import {
   el,
   ob,
   attr,
+  on,
   bind,
   Reactor,
   Observer,
@@ -74,7 +75,7 @@ import {
 
 It is also available directly from [unpkg](https://unpkg.com). You can import it in JavaScript using
 ```javascript
-import { el, attr, bind, ob, Reactor, Observer, hide, batch, shuck } from 'https://unpkg.com/@fynyky/elemental'
+import { el, attr, on, bind, ob, Reactor, Observer, hide, batch, shuck } from 'https://unpkg.com/@fynyky/elemental'
 ```
 
 
@@ -217,6 +218,22 @@ el('h1', attr('id', 'foo'))
 
 ```html
 <h1 id="foo"></h1>
+```
+
+Similarly the `on(event, fn)` function is provided as a shorthand for
+
+```javascript
+$ => { $.addEventListener(event, fn) }
+```
+
+This allows easy attaching of event listeners like this
+
+```javascript
+el('button', on('click', () => console.log('clicked!')))
+```
+
+```html
+<button></button>
 ```
 
 Similarly the `bind(reactor, key)` function is provided as a shorthand for
@@ -669,7 +686,7 @@ Summary
 
 ```javascript
 import { 
-  el, attr, bind, ob,
+  el, attr, on, bind, ob,
   Reactor, Observer, hide, batch, shuck 
 } from '@fynyky/elemental'
 
@@ -741,6 +758,11 @@ el('h1', ['foo', 'bar', 'qux']) // Creates <h1>foobarqux</h1>
 // These 2 are equivalent
 el('h1', attr('id', 'foo'))
 el('h1', self => self.setAttribute('id', 'foo'))
+
+// on is shorthand for addEventListener
+// These 2 are equivalent
+el('button', on('click', handler))
+el('button', self => self.addEventListener('click', handler))
 
 // bind is shorthand for 2 way binding with a reactor
 // These 2 are equivalent

--- a/src/elemental.js
+++ b/src/elemental.js
@@ -242,6 +242,18 @@ export function attr (attribute, value) {
   }
 }
 
+// Shorthand function to add event listeners to elements.
+// Usage: el('button', on('click', handler))
+//
+// @param {string} event - Event name
+// @param {Function} fn - Event handler function
+// @returns {Function} Function that adds the event listener when called
+export function on (event, fn) {
+  return ($) => {
+    $.addEventListener(event, fn)
+  }
+}
+
 // Shorthand function to bind input elements to reactor values.
 // Usage: el('input', attr('type', 'text'), bind(rx, 'foo'))
 //

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,2 @@
-export { el, attr, bind, ob } from './elemental.js'
+export { el, attr, on, bind, ob } from './elemental.js'
 export { Reactor, Observer, shuck, hide, batch } from 'reactorjs'

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 
 import { assert } from 'chai'
-import { el, attr, bind, ob, Reactor } from '../src/index.js'
+import { el, attr, on, bind, ob, Reactor } from '../src/index.js'
 
 afterEach(() => {
   document.body.innerHTML = ''
@@ -522,6 +522,13 @@ describe('Shorthands', () => {
       result.remove()
       done()
     }, 10)
+  })
+
+  it('attaches event listeners using on', () => {
+    let clicked = false
+    const result = el('button', on('click', () => { clicked = true }))
+    result.click()
+    assert.equal(clicked, true)
   })
 
   it('does 2 way binding', (done) => {


### PR DESCRIPTION
Mirrors the pattern of attr() and bind() — returns a configurator function that calls addEventListener on the element.