### PR TITLE
Add id-token: write permission to PR review workflow

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -9,6 +9,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      id-token: write
     steps:
       - uses: anthropics/claude-code-action@v1
         with:


### PR DESCRIPTION
Required for claude-code-action to fetch an OIDC token for GitHub authentication.