### PR TITLE
Use direct_prompt instead of prompt for automated PR review

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          prompt: |
+          direct_prompt: |
             Review this pull request and leave a thorough code review comment. Cover:
             - Bugs or logic errors
             - Security issues


### PR DESCRIPTION
The prompt field sets system context; direct_prompt is what triggers Claude to actually execute a task in automated (non-interactive) mode.