### PR TITLE
Allow gh tools so Claude can post PR review comments

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -20,7 +20,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          show_full_output: true
+          claude_args: --allowedTools "Bash(gh pr comment:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(git fetch:*)"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
The action runs in default permissionMode regardless of project settings, so gh commands (which require network access) need explicit --allowedTools. Read-only git commands already work; only gh pr and git fetch are blocked.