### PR TITLE
Cache Playwright browsers in CI to prevent download hangs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,5 +18,9 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           package-manager-cache: false
       - run: npm ci
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ hashFiles('package-lock.json') }}
       - run: npm test
       - run: npm publish

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,4 +14,8 @@ jobs:
         with:
           node-version: 24
       - run: npm ci
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ hashFiles('package-lock.json') }}
       - run: npm test


### PR DESCRIPTION
## Summary

- Adds `actions/cache@v4` for `~/.cache/ms-playwright` in both `test.yml` and `publish.yml`
- Cache key is based on `package-lock.json` hash, so it busts when Playwright version changes
- Placed after `npm ci` and before `npm test`, which is where `pretest` runs `npx playwright install --with-deps`

## Test plan

- [ ] CI passes on this PR
- [ ] On a second run (cache hit), verify the workflow completes faster with no browser download

🤖 Generated with [Claude Code](https://claude.com/claude-code)