### PR TITLE
Remove track_progress from security audit workflow

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -33,7 +33,6 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ github.token }}
-          track_progress: true
 
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
Removed track_progress option from CLAUDE_CODE_ACTION. It was causing failures because it can't run in scheduled action